### PR TITLE
feat: expose ScrapeHTML function in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ import "github.com/kkyr/go-recipe/pkg/recipe"
 func main() {
   url := "https://minimalistbaker.com/quick-pickled-jalapenos/"
 
-  recipe, err := recipe.ScrapeFrom(url)
-  if err != nil { 
+  recipe, err := recipe.ScrapeURL(url)
+  if err != nil {
       // handle err
   }
-  
-  ingredients, ok := recipe.Ingredients() 
+
+  ingredients, ok := recipe.Ingredients()
   instructions, ok := recipe.Instructions()
   // ... & more fields available
 }
@@ -53,7 +53,7 @@ Contributions are welcome! You can contribute in a few ways: by adding a custom 
 
 ### Custom scrapers
 
-Creating a custom scraper is easy as pie thanks to the code generator that's included in this package. 
+Creating a custom scraper is easy as pie thanks to the code generator that's included in this package.
 
 The generator requires two arguments: a link to a recipe on a website and the domain of the website that the recipe is hosted on. The domain is used to generate the source code (particularly the file and struct names), and the link is used to scrape recipe data, which is then used to generate a fully functioning unit test. If the generator is unable to scrape recipe data (which can happen if the website does not contain a Schema Recipe), a test will still be generated but test assertions will be made against empty fields.
 

--- a/doc.go
+++ b/doc.go
@@ -15,7 +15,7 @@
 //	func main() {
 //	  url := "https://minimalistbaker.com/quick-pickled-jalapenos/"
 //
-//	  recipe, err := recipe.ScrapeFrom(url)
+//	  recipe, err := recipe.ScrapeURL(url)
 //	  if err != nil {
 //		// handle err
 //	  }

--- a/pkg/recipe/recipe.go
+++ b/pkg/recipe/recipe.go
@@ -3,6 +3,7 @@ package recipe
 import (
 	"bytes"
 	"fmt"
+	"io"
 
 	"github.com/kkyr/go-recipe"
 	"github.com/kkyr/go-recipe/internal/html/scrape/schema"
@@ -26,7 +27,12 @@ func ScrapeFrom(urlStr string) (recipe.Scraper, error) {
 		return nil, fmt.Errorf("unable to GET url: %w", err)
 	}
 
-	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(body))
+	return ScrapeHTML(urlStr, bytes.NewReader(body))
+}
+
+// ScrapeHTML returns a Scraper that scrapes recipe data from the provided HTML.
+func ScrapeHTML(urlStr string, body io.Reader) (recipe.Scraper, error) {
+	doc, err := goquery.NewDocumentFromReader(body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse HTML document: %w", err)
 	}

--- a/pkg/recipe/recipe.go
+++ b/pkg/recipe/recipe.go
@@ -19,9 +19,9 @@ type httpClient interface {
 
 var client httpClient = http.NewClient()
 
-// ScrapeFrom retrieves the source at the provided url and returns a
+// ScrapeURL retrieves the source at the provided url and returns a
 // Scraper that scrapes recipe data from the retrieved HTML.
-func ScrapeFrom(urlStr string) (recipe.Scraper, error) {
+func ScrapeURL(urlStr string) (recipe.Scraper, error) {
 	body, err := client.Get(urlStr)
 	if err != nil {
 		return nil, fmt.Errorf("unable to GET url: %w", err)
@@ -31,6 +31,8 @@ func ScrapeFrom(urlStr string) (recipe.Scraper, error) {
 }
 
 // ScrapeHTML returns a Scraper that scrapes recipe data from the provided HTML.
+// the urlStr is used to determine if a specific scraper should be used, otherwise
+// a generic scraper is used.
 func ScrapeHTML(urlStr string, body io.Reader) (recipe.Scraper, error) {
 	doc, err := goquery.NewDocumentFromReader(body)
 	if err != nil {

--- a/pkg/recipe/recipe_internal_test.go
+++ b/pkg/recipe/recipe_internal_test.go
@@ -31,7 +31,7 @@ const htmlSchemaRecipe = `<html>
     </head>
 </html>`
 
-func TestScrapeFrom(t *testing.T) {
+func TestScrapeURL(t *testing.T) {
 	assert := assert.New(t)
 
 	client = &mockHTTPClient{
@@ -41,7 +41,7 @@ func TestScrapeFrom(t *testing.T) {
 	}
 
 	t.Run("using custom scraper", func(t *testing.T) {
-		scraper, err := ScrapeFrom(custom.MinimalistBakerHost)
+		scraper, err := ScrapeURL(custom.MinimalistBakerHost)
 		assert.Require().Nil(err)
 
 		if _, ok := scraper.(*custom.MinimalistBakerScraper); !ok {
@@ -54,7 +54,7 @@ func TestScrapeFrom(t *testing.T) {
 	})
 
 	t.Run("using default scraper", func(t *testing.T) {
-		scraper, err := ScrapeFrom("")
+		scraper, err := ScrapeURL("")
 		assert.Require().Nil(err)
 
 		if _, ok := scraper.(*schema.RecipeScraper); !ok {
@@ -67,7 +67,7 @@ func TestScrapeFrom(t *testing.T) {
 	})
 }
 
-func TestScrapeFrom_Err(t *testing.T) {
+func TestScrapeURL_Err(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("using bad document", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestScrapeFrom_Err(t *testing.T) {
 			},
 		}
 
-		_, err := ScrapeFrom("")
+		_, err := ScrapeURL("")
 		assert.NotNil(err)
 	})
 
@@ -90,7 +90,7 @@ func TestScrapeFrom_Err(t *testing.T) {
 			},
 		}
 
-		_, err := ScrapeFrom("")
+		_, err := ScrapeURL("")
 		assert.ErrorIs(err, boom)
 	})
 }


### PR DESCRIPTION
This PR adds the ability to pass the HTML body via an `io.Reader` to a new function `ScrapeHTML`. 

No business code was written, I've just moved the parts that work with the body into their own function and call it from the `ScrapeFrom` function